### PR TITLE
Fix RTP audio issues revert #47c5c8f

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8907,6 +8907,8 @@ SWITCH_DECLARE(int) switch_rtp_write_frame(switch_rtp_t *rtp_session, switch_fra
 		data = frame->data;
 		len = frame->datalen;
 		ts = rtp_session->flags[SWITCH_RTP_FLAG_RAW_WRITE] ? (uint32_t) frame->timestamp : 0;
+		if (!ts) ts = rtp_session->last_write_ts + rtp_session->samples_per_interval;
+		
 	}
 
 	/*


### PR DESCRIPTION
Revert "[Core] Fix short-circuit in write timestamp calc" This reverts commit 47c5c8f.

If packet loss (or even just jitter) is encountered during recording, Freeswitch will currently generate new packages to fill in the gaps.

Without this revert, the inserted package(s) will get an incorrect RTP timestamp, and then the timestamp will revert to normal as soon as the stream of non-generated packages resumes See signalwire#1651 for additional information.

Source
https://github.com/briteback/freeswitch/commit/9f8968ccabb8a4e0353016d4ea0ff99561b005f1