### PR TITLE
[mod_av] Add support for FFmpeg 6.0, 6.1, 7.0, and 7.1

### DIFF
--- a/src/mod/applications/mod_av/avcodec.c
+++ b/src/mod/applications/mod_av/avcodec.c
@@ -1557,7 +1557,11 @@ static switch_status_t switch_h264_encode(switch_codec_t *codec, switch_frame_t 
 		}
 
 		 avframe->pict_type = AV_PICTURE_TYPE_I;
+#if (LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V)
+		 avframe->flags |= AV_FRAME_FLAG_KEY;
+#else
 		 avframe->key_frame = 1;
+#endif
 		 context->last_keyframe_request = switch_time_now();
 	}
 
@@ -1600,9 +1604,14 @@ GCC_DIAG_ON(deprecated-declarations)
 		}
 #endif
 
+#if (LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V)
+	if (context->need_key_frame && (avframe->flags & AV_FRAME_FLAG_KEY)) {
+		avframe->flags &= ~AV_FRAME_FLAG_KEY;
+#else
 	if (context->need_key_frame && avframe->key_frame == 1) {
-		avframe->pict_type = 0;
 		avframe->key_frame = 0;
+#endif
+		avframe->pict_type = 0;
 		context->need_key_frame = 0;
 	}
 

--- a/src/mod/applications/mod_av/avcodec.c
+++ b/src/mod/applications/mod_av/avcodec.c
@@ -1227,8 +1227,14 @@ static switch_status_t open_encoder(h264_codec_context_t *context, uint32_t widt
 
 	if (context->encoder_ctx) {
 		if (avcodec_is_open(context->encoder_ctx)) {
+#if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_7_V)
 			avcodec_close(context->encoder_ctx);
+#else
+			/* avcodec_close() will be called in avcodec_free_context() */
+			avcodec_free_context(&context->encoder_ctx);
+#endif
 		}
+
 		av_free(context->encoder_ctx);
 		context->encoder_ctx = NULL;
 	}
@@ -1320,8 +1326,14 @@ FF_ENABLE_DEPRECATION_WARNINGS
 
 		if (context->encoder_ctx) {
 			if (avcodec_is_open(context->encoder_ctx)) {
+#if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_7_V)
 				avcodec_close(context->encoder_ctx);
+#else
+				/* avcodec_close() will be called in avcodec_free_context() */
+				avcodec_free_context(&context->encoder_ctx);
+#endif
 			}
+
 			av_free(context->encoder_ctx);
 			context->encoder_ctx = NULL;
 		}
@@ -1557,7 +1569,7 @@ static switch_status_t switch_h264_encode(switch_codec_t *codec, switch_frame_t 
 		}
 
 		 avframe->pict_type = AV_PICTURE_TYPE_I;
-#if (LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V)
+#if ((LIBAVCODEC_VERSION_MAJOR == LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V) || LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_7_V)
 		 avframe->flags |= AV_FRAME_FLAG_KEY;
 #else
 		 avframe->key_frame = 1;
@@ -1604,7 +1616,7 @@ GCC_DIAG_ON(deprecated-declarations)
 		}
 #endif
 
-#if (LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V)
+#if ((LIBAVCODEC_VERSION_MAJOR == LIBAVCODEC_6_V && LIBAVCODEC_VERSION_MINOR >= LIBAVCODEC_61_V) || LIBAVCODEC_VERSION_MAJOR >= LIBAVCODEC_7_V)
 	if (context->need_key_frame && (avframe->flags & AV_FRAME_FLAG_KEY)) {
 		avframe->flags &= ~AV_FRAME_FLAG_KEY;
 #else
@@ -1871,14 +1883,30 @@ static switch_status_t switch_h264_destroy(switch_codec_t *codec)
 
 	switch_buffer_destroy(&context->nalu_buffer);
 	if (context->decoder_ctx) {
-		if (avcodec_is_open(context->decoder_ctx)) avcodec_close(context->decoder_ctx);
+		if (avcodec_is_open(context->decoder_ctx)) {
+#if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_7_V)
+				avcodec_close(context->decoder_ctx);
+#else
+				/* avcodec_close() will be called in avcodec_free_context() */
+				avcodec_free_context(&context->decoder_ctx);
+#endif
+		}
+
 		av_free(context->decoder_ctx);
 	}
 
 	switch_img_free(&context->img);
 
 	if (context->encoder_ctx) {
-		if (avcodec_is_open(context->encoder_ctx)) avcodec_close(context->encoder_ctx);
+		if (avcodec_is_open(context->encoder_ctx)) {
+#if (LIBAVCODEC_VERSION_MAJOR < LIBAVCODEC_7_V)
+			avcodec_close(context->encoder_ctx);
+#else
+			/* avcodec_close() will be called in avcodec_free_context() */
+			avcodec_free_context(&context->encoder_ctx);
+#endif
+		}
+
 		av_free(context->encoder_ctx);
 	}
 

--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -623,8 +623,13 @@ static switch_status_t add_stream(av_file_context_t *context, MediaStream *mst, 
 		c->rc_initial_buffer_occupancy = buffer_bytes * 8;
 
 		if (codec_id == AV_CODEC_ID_H264) {
+#if (LIBAVFORMAT_VERSION_MAJOR >= LIBAVFORMAT_6_V && LIBAVFORMAT_VERSION_MINOR >= LIBAVFORMAT_61_V)
+GCC_DIAG_OFF(deprecated-declarations)
+#endif
 			c->ticks_per_frame = 2;
-
+#if (LIBAVFORMAT_VERSION_MAJOR >= LIBAVFORMAT_6_V && LIBAVFORMAT_VERSION_MINOR >= LIBAVFORMAT_61_V)
+GCC_DIAG_ON(deprecated-declarations)
+#endif
 
 			c->flags|=AV_CODEC_FLAG_LOOP_FILTER;   // flags=+loop
 			c->me_cmp|= 1;  // cmp=+chroma, where CHROMA = 1
@@ -3212,6 +3217,9 @@ static switch_status_t av_file_read_video(switch_file_handle_t *handle, switch_f
 
 	if ((c = av_get_codec_context(mst)) && c->time_base.num) {
 		cp = av_stream_get_parser(st);
+#if (LIBAVFORMAT_VERSION_MAJOR >= LIBAVFORMAT_6_V && LIBAVFORMAT_VERSION_MINOR >= LIBAVFORMAT_61_V)
+GCC_DIAG_OFF(deprecated-declarations)
+#endif
 		ticks = cp ? cp->repeat_pict + 1 : c->ticks_per_frame;
 		// mst->next_pts += ((int64_t)AV_TIME_BASE * st->codec->time_base.num * ticks) / st->codec->time_base.den;
 	}
@@ -3221,6 +3229,9 @@ static switch_status_t av_file_read_video(switch_file_handle_t *handle, switch_f
 			context->video_start_time, ticks, c ? c->ticks_per_frame : -1, st->time_base.num, st->time_base.den, c ? c->time_base.num : -1, c ? c->time_base.den : -1,
 			st->start_time, st->duration == AV_NOPTS_VALUE ? context->fc->duration / AV_TIME_BASE * 1000 : st->duration, st->nb_frames, av_q2d(st->time_base));
 	}
+#if (LIBAVFORMAT_VERSION_MAJOR >= LIBAVFORMAT_6_V && LIBAVFORMAT_VERSION_MINOR >= LIBAVFORMAT_61_V)
+GCC_DIAG_ON(deprecated-declarations)
+#endif
 
  again:
 

--- a/src/mod/applications/mod_av/mod_av.h
+++ b/src/mod/applications/mod_av/mod_av.h
@@ -42,9 +42,11 @@
 
 #define LIBAVCODEC_V 59 /* FFmpeg version >= 5.1 */
 #define LIBAVCODEC_6_V 60 /* FFmpeg version >= 6.0 */
+#define LIBAVCODEC_7_V 61 /* FFmpeg version >= 7.0 */
 #define LIBAVCODEC_61_V 31 /* FFmpeg version >= 6.1 */
 #define LIBAVFORMAT_V 59 /* FFmpeg version >= 5.1 */
 #define LIBAVFORMAT_6_V 60 /* FFmpeg version >= 6.0 */
+#define LIBAVFORMAT_7_V 61 /* FFmpeg version >= 7.0 */
 #define LIBAVFORMAT_61_V 16 /* FFmpeg version >= 6.1 */
 #define LIBAVUTIL_V 57 /* FFmpeg version >= 5.1 */
 

--- a/src/mod/applications/mod_av/mod_av.h
+++ b/src/mod/applications/mod_av/mod_av.h
@@ -42,6 +42,7 @@
 
 #define LIBAVCODEC_V 59
 #define LIBAVFORMAT_V 59
+#define LIBAVFORMAT_6_V 60
 #define LIBAVUTIL_V 57
 
 struct mod_av_globals {

--- a/src/mod/applications/mod_av/mod_av.h
+++ b/src/mod/applications/mod_av/mod_av.h
@@ -40,10 +40,13 @@
 #ifndef MOD_AV_H
 #define MOD_AV_H
 
-#define LIBAVCODEC_V 59
-#define LIBAVFORMAT_V 59
-#define LIBAVFORMAT_6_V 60
-#define LIBAVUTIL_V 57
+#define LIBAVCODEC_V 59 /* FFmpeg version >= 5.1 */
+#define LIBAVCODEC_6_V 60 /* FFmpeg version >= 6.0 */
+#define LIBAVCODEC_61_V 31 /* FFmpeg version >= 6.1 */
+#define LIBAVFORMAT_V 59 /* FFmpeg version >= 5.1 */
+#define LIBAVFORMAT_6_V 60 /* FFmpeg version >= 6.0 */
+#define LIBAVFORMAT_61_V 16 /* FFmpeg version >= 6.1 */
+#define LIBAVUTIL_V 57 /* FFmpeg version >= 5.1 */
 
 struct mod_av_globals {
 	int debug;


### PR DESCRIPTION
1. **FFmpeg 6.0 Support** (original: `9dccd0b6e6`)
   - Cherry-picked as: `2e257bd823`
   - API changes: `avformat_alloc_output_context2()` signature update
   - Interrupt callback mechanism for context allocation

2. **FFmpeg 6.1 Support** (original: `58776f3eed`)
   - Cherry-picked as: `3de5930136`
   - Key frame handling: `AV_FRAME_FLAG_KEY` vs deprecated `key_frame` field
   - GCC deprecation warning guards added

3. **FFmpeg 7.0 Support** (original: `1fd9ac9dd1`)
   - Cherry-picked as: `55707a7501`
   - Major API change: `avcodec_close()` replaced with `avcodec_free_context()`
   - Updated version comparison macros throughout

4. **FFmpeg 7.1 Support** (original: `066b92c589`)
   - Cherry-picked as: `d169aae796`
   - New sample format negotiation via `avcodec_get_supported_config()`