### PR TITLE
Remove merge conflict markers from switch_core.c

### DIFF
--- a/tests/unit/switch_core.c
+++ b/tests/unit/switch_core.c
@@ -53,7 +53,6 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEARDOWN_END()
 
-<<<<<<< HEAD
 
 		FST_TEST_BEGIN(test_switch_regex)
 		{


### PR DESCRIPTION
Fix a merge conflict issue that was caused by [Debian 13 Build Support and PCRE2 Upgrade](https://github.com/fusionpbx/freeswitch/pull/14/changes#top)
#14