### PR TITLE
[Unit-tests] Fix test framework error on newer compiler: 'strncpy'

### DIFF
--- a/src/include/test/switch_fct.h
+++ b/src/include/test/switch_fct.h
@@ -254,10 +254,18 @@ fctstr_safe_cpy(char *dst, char const *src, size_t num)
     FCT_ASSERT( num > 0 );
 #if defined(WIN32) && _MSC_VER >= 1400
     strncpy_s(dst, num, src, _TRUNCATE);
+    dst[num - 1] = '\0';
 #else
-    strncpy(dst, src, num - 1);
+    {
+        size_t i;
+
+        for (i = 0; (i < num - 1) && src[i] != '\0'; ++i) {
+            dst[i] = src[i];
+        }
+
+        dst[i] = '\0';
+    }
 #endif
-    dst[num-1] = '\0';
 }
 
 /* Isolate the vsnprintf implementation */


### PR DESCRIPTION
[Unit-tests] Fix test framework error on newer compiler: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]#2839